### PR TITLE
fix(streaming): preserve canonical tool call IDs

### DIFF
--- a/open_webui_openrouter_pipe/streaming/streaming_core.py
+++ b/open_webui_openrouter_pipe/streaming/streaming_core.py
@@ -464,6 +464,7 @@ class StreamingHandler:
         streamed_tool_call_ids: set[str] = set()
         streamed_tool_call_indices: dict[str, int] = {}
         tool_call_names: dict[str, str] = {}
+        tool_call_item_ids: dict[str, str] = {}
         streamed_tool_call_args: dict[str, str] = {}
         streamed_tool_call_name_sent: set[str] = set()
         emitted_tool_call_items: set[str] = set()
@@ -1413,7 +1414,9 @@ class StreamingHandler:
                         "response.function_call_arguments.done",
                     }:
                         try:
-                            raw_call_id = event.get("item_id") or event.get("call_id") or event.get("id")
+                            raw_item_id = event.get("item_id")
+                            item_id = raw_item_id.strip() if isinstance(raw_item_id, str) else ""
+                            raw_call_id = tool_call_item_ids.get(item_id) or event.get("call_id") or item_id or event.get("id")
                             call_id = raw_call_id.strip() if isinstance(raw_call_id, str) else ""
                             if not call_id:
                                 continue
@@ -1627,9 +1630,13 @@ class StreamingHandler:
                         if owui_tool_passthrough and item_type == "function_call":
                             raw_call_id = item.get("call_id") or item.get("id")
                             call_id = raw_call_id.strip() if isinstance(raw_call_id, str) else ""
+                            raw_item_id = item.get("id")
+                            item_id = raw_item_id.strip() if isinstance(raw_item_id, str) else ""
                             raw_name = item.get("name")
                             tool_name = raw_name.strip() if isinstance(raw_name, str) else ""
                             if call_id:
+                                if item_id:
+                                    tool_call_item_ids[item_id] = call_id
                                 streamed_tool_call_indices.setdefault(
                                     call_id, len(streamed_tool_call_indices)
                                 )

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -829,22 +829,22 @@ class TestToolPassthrough:
         events = [
             {
                 "type": "response.output_item.added",
-                "item": {"type": "function_call", "call_id": "call-1", "id": "call-1", "name": "get_weather"},
+                "item": {"type": "function_call", "call_id": "call-1", "id": "fc_tmp_1", "name": "get_weather"},
             },
             {
                 "type": "response.function_call_arguments.delta",
-                "item_id": "call-1",
+                "item_id": "fc_tmp_1",
                 "name": "get_weather",
                 "delta": '{"city":',
             },
             {
                 "type": "response.function_call_arguments.delta",
-                "item_id": "call-1",
+                "item_id": "fc_tmp_1",
                 "delta": '"NYC"}',
             },
             {
                 "type": "response.function_call_arguments.done",
-                "item_id": "call-1",
+                "item_id": "fc_tmp_1",
                 "name": "get_weather",
                 "arguments": '{"city":"NYC"}',
             },
@@ -881,7 +881,11 @@ class TestToolPassthrough:
         )
 
         tool_calls = _collect_events_of_type(emitted, "chat:tool_calls")
-        assert tool_calls, "Expected tool call events in passthrough mode"
+        assert len(tool_calls) == 2, "The completed response must not duplicate streamed calls"
+        assert all(
+            event["data"]["tool_calls"][0]["id"] == "call-1"
+            for event in tool_calls
+        )
         assert tool_calls[0]["data"]["tool_calls"][0]["function"]["name"] == "get_weather"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Open-WebUI tool passthrough now uses the Responses API `call_id` consistently while streamed function arguments arrive under a separate output-item ID. This prevents one upstream function invocation from being emitted as two distinct Open WebUI calls and therefore executed twice.

## Why / Context
OpenRouter's Responses stream can use an output-item ID such as `fc_tmp_*` in argument-delta events while its completed response uses the invocation `call_id`, such as `call_*`. The prior passthrough path exposed the first ID during streaming and the second ID at completion, so Open WebUI treated them as separate calls and sent duplicate results into the continuation.

## Changes
- **Streaming passthrough**: record each function output-item ID's associated canonical `call_id` when the item is added.
- **Argument events**: resolve streamed `item_id` values through that association before emitting `chat:tool_calls`.
- **Regression test**: cover a stream whose output-item ID and function `call_id` differ, asserting only the canonical ID is emitted and completion does not duplicate the call.

## Testing
- `uv run --with pytest --with pytest-asyncio --extra dev pytest -q tests/test_streaming_handler.py::TestToolPassthrough`
